### PR TITLE
Drop activity.activityTypeId default from previous migrations since a…

### DIFF
--- a/prisma/migrations/20210506180522_drop_activity_type_default/migration.sql
+++ b/prisma/migrations/20210506180522_drop_activity_type_default/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "activities" ALTER COLUMN "activityTypeId" DROP DEFAULT;


### PR DESCRIPTION
…ll activities should have a default from that migration