### PR TITLE
Fix search menu type pickers

### DIFF
--- a/packages/components/layout/side-bar/search-menu/index.tsx
+++ b/packages/components/layout/side-bar/search-menu/index.tsx
@@ -22,6 +22,7 @@ export interface SearchMenuProps {
 export const SearchMenu: FC<SearchMenuProps> = ({ acterTypes, searchType }) => {
   const classes = useStyles()
   const router = useRouter()
+  const { types } = router.query
 
   const { USER, ACTIVITY, GROUP } = ActerTypes
   const { MEETING } = ActivityTypes
@@ -31,7 +32,7 @@ export const SearchMenu: FC<SearchMenuProps> = ({ acterTypes, searchType }) => {
       ![ACTIVITY, MEETING, GROUP, USER].includes(type.name as ActerTypes)
   )
   const [filterSubTypes, setFilterSubTypes] = useState(
-    subTypes.map((type) => type.name)
+    types ? (types as string).split(',') : subTypes.map((type) => type.name)
   )
 
   useEffect(() => {

--- a/packages/components/layout/side-bar/search-menu/type.tsx
+++ b/packages/components/layout/side-bar/search-menu/type.tsx
@@ -28,17 +28,13 @@ export const Type: FC<TypeProps> = ({
   const type: string = subTypeName
   const classes = useStyles({ type })
 
-  const handleChange = () => {
-    const newFilterSubTypes = [...filterSubTypes]
-
-    if (newFilterSubTypes.includes(subTypeName)) {
-      const filteredSubtypeNames = newFilterSubTypes.filter(
-        (item) => item === subTypeName
-      )
-      onChange([...filteredSubtypeNames])
-    } else {
-      onChange([...newFilterSubTypes, subTypeName])
+  const handleChange = (addToList: boolean) => {
+    if (addToList) {
+      if (filterSubTypes.includes(subTypeName)) return
+      return onChange([...filterSubTypes, subTypeName])
     }
+
+    onChange(filterSubTypes.filter((name) => name !== subTypeName))
   }
 
   return (


### PR DESCRIPTION
Noticed that the search type filters switches were working in reverse: when one clicked, for example, "Events" to turn it off, the opposite happened and *only* "Events" was selected.