### PR TITLE
Judemusyoki/sc 1492 make avatar background color white by default fix

### DIFF
--- a/packages/components/acter/avatar.tsx
+++ b/packages/components/acter/avatar.tsx
@@ -73,7 +73,7 @@ export const Avatar = withStyles((theme: Theme) =>
       width: ({ size }: { size: number }) => theme.spacing(size),
       height: ({ size }: { size: number }) => theme.spacing(size),
       fontSize: '100%',
-      border: '1px solid white',
+      border: `1px solid ${theme.palette.secondary.dark}`,
     },
   })
 )(MuiAvatar)


### PR DESCRIPTION
Fixed the sidebar acter avatars background color and font color
<img width="284" alt="Screenshot 2021-09-24 at 00 30 09" src="https://user-images.githubusercontent.com/52712074/134586813-ce72b0c6-c780-4252-95f5-22640a1cf738.png">

Also as @emilvincentz added I included a border on the avatar
<img width="253" alt="Screenshot 2021-09-27 at 22 30 03" src="https://user-images.githubusercontent.com/52712074/135034918-d2b07b06-547d-44b0-b826-471f70f6e599.png">

