### PR TITLE
Jude/ cookie widget debug flag fix

### DIFF
--- a/packages/components/layout/cookie-bar.tsx
+++ b/packages/components/layout/cookie-bar.tsx
@@ -8,7 +8,7 @@ import { makeStyles, Theme } from '@material-ui/core/styles'
 export const CookieBar: FC = () => {
   const classes = useStyles()
   return (
-    <CookieConsent debug={true} style={{ zIndex: 1300 }}>
+    <CookieConsent style={{ zIndex: 1300 }}>
       This website uses cookies to enhance the user experience.
       <Link href={'/privacy-policy'}>
         <a className={classes.link} target="_blank">


### PR DESCRIPTION
Forgot to remove a debug flag on the cookie component that makes the cookie prompt not disappear after user clicks "I understand"