### PR TITLE
WIP: Jude/ correct time when entered with keyboard time picker

### DIFF
--- a/packages/components/util/pickers/time-picker-field.tsx
+++ b/packages/components/util/pickers/time-picker-field.tsx
@@ -4,7 +4,7 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import { AccessTime } from '@material-ui/icons'
 
 import { Field } from 'formik'
-import { KeyboardTimePicker } from 'formik-material-ui-pickers'
+import { TimePicker } from 'formik-material-ui-pickers'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -27,7 +27,7 @@ export const TimePickerField: FC<TimePickerProps> = (props) => {
 
   return (
     <Field
-      component={KeyboardTimePicker}
+      component={TimePicker}
       fullWidth
       label={label}
       name={name}
@@ -39,7 +39,6 @@ export const TimePickerField: FC<TimePickerProps> = (props) => {
       InputAdornmentProps={{ position: 'start' }}
       InputProps={{ className: classes.timepicker }}
       required={required}
-      disabledKeyboardNavigation
     />
   )
 }


### PR DESCRIPTION
The reported was caused but user typing time instead of picking it using the UI time picker. I've disabled keyboard entry of time in the _**time picker input**_ in the form.

<img width="441" alt="Screenshot 2021-10-25 at 11 41 40" src="https://user-images.githubusercontent.com/52712074/138672935-a9abfe6a-8d53-40c0-8f4e-d9918b9b66ef.png">
