### PR TITLE
Restrict TypeGraphQL resolvers to ones used

### DIFF
--- a/packages/schema/generate-schema.ts
+++ b/packages/schema/generate-schema.ts
@@ -2,65 +2,36 @@ import 'reflect-metadata'
 
 import { GraphQLSchema } from 'graphql/type'
 import path from 'path'
-import { buildSchema, UseMiddleware } from 'type-graphql'
-
-import { NotificationQueueType } from '@acter/lib/constants'
-import {
-  ResolversEnhanceMap,
-  applyResolversEnhanceMap,
-  crudResolvers,
-  relationResolvers,
-} from '@acter/schema/generated'
-import { CheckActerExists } from '@acter/schema/middlewares/check-acter-exists'
-import { CheckUserAccess } from '@acter/schema/middlewares/check-user-access'
-import { QueueInviteEmail } from '@acter/schema/middlewares/queue-invite-email'
-import { QueuePostNotifications } from '@acter/schema/middlewares/queue-post-notifications'
-import { ActerResolver } from '@acter/schema/resolvers/acter'
-import { ActerConnectionResolver } from '@acter/schema/resolvers/acter-connection'
-import { SearchResolver } from '@acter/schema/resolvers/search'
+import { buildSchema } from 'type-graphql'
 
 import { authChecker } from './auth-checker'
+import {
+  resolvers,
+  applyResolversEnhanceMap,
+  resolversEnhanceMap,
+} from './resolvers'
 
 let schema
 
 export const generateSchema = async (
   writeSchema = false
 ): Promise<GraphQLSchema> => {
-  const resolversEnhanceMap: ResolversEnhanceMap = {
-    Acter: {
-      findFirstActer: [UseMiddleware(CheckActerExists, CheckUserAccess)],
-    },
-    Invite: {
-      createManyInvite: [UseMiddleware(QueueInviteEmail)],
-      updateInvite: [UseMiddleware(QueueInviteEmail)],
-    },
-    Post: {
-      createPost: [
-        UseMiddleware(QueuePostNotifications(NotificationQueueType.NEW_POST)),
-      ],
-    },
-  }
-
   applyResolversEnhanceMap(resolversEnhanceMap)
 
   if (!schema) {
     const generatedPath = path.join(__dirname, 'generated')
     const graphQLSchemaFilename = path.join(generatedPath, 'schema.graphql')
-    console.debug('In generateSchema with writeSchema', writeSchema)
+    const timeStart = new Date().getTime()
     schema = await buildSchema({
       authChecker,
-      resolvers: [
-        ...crudResolvers,
-        ...relationResolvers,
-        ActerResolver,
-        ActerConnectionResolver,
-        SearchResolver,
-      ],
+      resolvers,
       validate: false,
       dateScalarMode: 'isoDate',
       // emitSchemaFile: schemaExists ? false : graphQLSchemaFilename,
       emitSchemaFile: writeSchema ? graphQLSchemaFilename : false,
     })
+    const timeEnd = new Date().getTime()
+    console.debug(`Schema built in ${timeEnd - timeStart} ms`)
   } else {
     console.debug('Using existing schema')
   }

--- a/packages/schema/resolvers/index.ts
+++ b/packages/schema/resolvers/index.ts
@@ -1,0 +1,100 @@
+import { NonEmptyArray, UseMiddleware } from 'type-graphql'
+
+import { NotificationQueueType } from '@acter/lib/constants'
+import { ResolversEnhanceMap } from '@acter/schema/generated'
+import {
+  relationResolvers,
+  FindFirstActerResolver,
+  FindUniqueActerResolver,
+  FindManyActerTypeResolver,
+  FindManyActerConnectionResolver,
+  FindManyActivityResolver,
+  FindManyActivityTypeResolver,
+  FindUniqueInviteResolver,
+  FindManyInviteResolver,
+  FindManyNotificationResolver,
+  FindManyLinkResolver,
+  FindFirstNotificationResolver,
+  FindUniquePostResolver,
+  FindManyPostResolver,
+  FindManyInterestTypeResolver,
+  FindUniqueUserResolver,
+  UpdateActerResolver,
+  CreatePostResolver,
+  DeleteLinkResolver,
+  DeletePostReactionResolver,
+  DeletePostResolver,
+  UpdateInviteResolver,
+  CreateManyInviteResolver,
+  CreateLinkResolver,
+  UpdateLinkResolver,
+  UpdateNotificationResolver,
+  UpdateManyNotificationResolver,
+  CreateManyPostResolver,
+  CreatePostReactionResolver,
+  UpdatePostResolver,
+  UpdateUserResolver,
+} from '@acter/schema/generated'
+import { CheckActerExists } from '@acter/schema/middlewares/check-acter-exists'
+import { CheckUserAccess } from '@acter/schema/middlewares/check-user-access'
+import { QueueInviteEmail } from '@acter/schema/middlewares/queue-invite-email'
+import { QueuePostNotifications } from '@acter/schema/middlewares/queue-post-notifications'
+import { ActerResolver } from '@acter/schema/resolvers/acter'
+import { ActerConnectionResolver } from '@acter/schema/resolvers/acter-connection'
+import { SearchResolver } from '@acter/schema/resolvers/search'
+
+export { applyResolversEnhanceMap } from '@acter/schema/generated'
+
+export const resolversEnhanceMap: ResolversEnhanceMap = {
+  Acter: {
+    findFirstActer: [UseMiddleware(CheckActerExists, CheckUserAccess)],
+  },
+  Invite: {
+    createManyInvite: [UseMiddleware(QueueInviteEmail)],
+    updateInvite: [UseMiddleware(QueueInviteEmail)],
+  },
+  Post: {
+    createPost: [
+      UseMiddleware(QueuePostNotifications(NotificationQueueType.NEW_POST)),
+    ],
+  },
+}
+
+//eslint-disable-next-line @typescript-eslint/ban-types
+export const resolvers: NonEmptyArray<Function> = [
+  ...relationResolvers,
+  FindFirstActerResolver,
+  FindUniqueActerResolver,
+  FindManyActerTypeResolver,
+  FindManyActerConnectionResolver,
+  FindManyActivityResolver,
+  FindManyActivityTypeResolver,
+  FindUniqueInviteResolver,
+  FindManyInviteResolver,
+  FindManyNotificationResolver,
+  FindManyLinkResolver,
+  FindFirstNotificationResolver,
+  FindUniquePostResolver,
+  FindManyPostResolver,
+  FindManyInterestTypeResolver,
+  FindUniqueUserResolver,
+  UpdateActerResolver,
+  CreatePostResolver,
+  DeleteLinkResolver,
+  DeletePostReactionResolver,
+  DeletePostResolver,
+  UpdateInviteResolver,
+  CreateManyInviteResolver,
+  CreateLinkResolver,
+  UpdateLinkResolver,
+  UpdateNotificationResolver,
+  UpdateManyNotificationResolver,
+  CreateManyPostResolver,
+  CreatePostReactionResolver,
+  UpdatePostResolver,
+  UpdateUserResolver,
+  // custom
+  ActerResolver,
+  ActerConnectionResolver,
+  SearchResolver,
+]


### PR DESCRIPTION
This *might* increase dev velocity by a lot, but need to test more.