### PR TITLE
Add meyerweb css reset

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -46,6 +46,7 @@
     "react-hotjar": "^5.0.0",
     "react-use-intercom": "1.4.0",
     "reflect-metadata": "0.1.13",
+    "reset-css": "^5.0.1",
     "type-graphql": "1.1.1",
     "typescript": "4.4.3",
     "urql": "2.0.5"

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -1,5 +1,7 @@
 import 'reflect-metadata'
 
+import 'reset-css';
+
 import React, { FC, ReactElement, ReactNode, useEffect } from 'react'
 import { hotjar } from 'react-hotjar'
 import { IntercomProvider } from 'react-use-intercom'

--- a/yarn.lock
+++ b/yarn.lock
@@ -242,6 +242,7 @@ __metadata:
     react-hotjar: ^5.0.0
     react-use-intercom: 1.4.0
     reflect-metadata: 0.1.13
+    reset-css: ^5.0.1
     type-graphql: 1.1.1
     typescript: 4.4.3
     urql: 2.0.5
@@ -23805,6 +23806,13 @@ __metadata:
   version: 2.0.0
   resolution: "require-main-filename@npm:2.0.0"
   checksum: e9e294695fea08b076457e9ddff854e81bffbe248ed34c1eec348b7abbd22a0d02e8d75506559e2265e96978f3c4720bd77a6dad84755de8162b357eb6c778c7
+  languageName: node
+  linkType: hard
+
+"reset-css@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "reset-css@npm:5.0.1"
+  checksum: b93380a2c691bfc85344bfa07e781266a2f58fef194c1aec61923d4591d30d73f54a12e4fe32b48668ce9bc82c2d42715e7e9fdd108d85b3c93b2a319f0a077c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This fixes i.e. the spacing between lines in profile and organization descriptions. 

Before:
<img width="120" alt="Screen Shot 2022-10-19 at 20 59 47" src="https://user-images.githubusercontent.com/74932975/196780477-bbf8d1bd-b6b8-4ea1-9eed-3ee240fcab9f.png">
<img width="102" alt="Screen Shot 2022-10-19 at 20 59 03" src="https://user-images.githubusercontent.com/74932975/196780527-99250073-2861-4d60-8655-5b23dd7cb0f3.png">


After:
<img width="105" alt="Screen Shot 2022-10-19 at 20 59 09" src="https://user-images.githubusercontent.com/74932975/196780357-45537ac2-6ace-490d-a850-0a32fa590a6e.png">
<img width="102" alt="Screen Shot 2022-10-19 at 20 59 03" src="https://user-images.githubusercontent.com/74932975/196780358-10f5387d-c25e-49c5-bb3c-6a0c627608cc.png">
