### PR TITLE
Bump node from 16 to 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "path": false
   },
   "engines": {
-    "node": "16.x",
+    "node": "18.x",
     "yarn": "3.x"
   },
   "resolutions": {


### PR DESCRIPTION
Updating the engine version should be enough, as per the documentation from Heroku: https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version